### PR TITLE
Use apply_changes/2 in Engine

### DIFF
--- a/apps/draw/lib/draw/engine.ex
+++ b/apps/draw/lib/draw/engine.ex
@@ -13,7 +13,7 @@ defmodule Draw.Engine do
   @doc """
   Prepare a new canvas with given size.
   """
-  @spec new_canvas(size :: point()) :: Canvas.t()
+  @spec new_canvas(size :: point() | nil) :: Canvas.t()
   def new_canvas(size \\ nil)
 
   def new_canvas(nil) do

--- a/apps/draw/lib/draw/engine.ex
+++ b/apps/draw/lib/draw/engine.ex
@@ -31,10 +31,10 @@ defmodule Draw.Engine do
   For now it just modifies fields.
   """
   @spec apply_operation(Canvas.t(), Operation.t()) :: {:ok, Canvas.t()} | {:error, atom()}
-  def apply_operation(%Canvas{} = canvas, %{} = operation) do
+  def apply_operation(%Canvas{} = canvas, operation) do
     case Operation.process(operation, canvas) do
-      {:ok, canvas} ->
-        {:ok, canvas}
+      {:ok, changes} ->
+        Canvas.apply_changes(canvas, changes)
 
       {:error, error} ->
         Logger.error("Illegal operation #{inspect(operation)} #{inspect(error)}")

--- a/apps/draw/lib/draw/engine/canvas.ex
+++ b/apps/draw/lib/draw/engine/canvas.ex
@@ -5,6 +5,7 @@ defmodule Draw.Engine.Canvas do
 
   alias Draw.Engine
   alias Draw.Engine.Canvas
+  alias Draw.Engine.Canvas.Changes
 
   @type t :: %Canvas{}
 
@@ -61,5 +62,19 @@ defmodule Draw.Engine.Canvas do
     else
       {:error, :out_of_bounds}
     end
+  end
+
+  @doc """
+  Apply changes to the Canvas fields. Will check if the changes go out of bounds and return
+  error tuple `{:error, :out_of_bounds}` in such a case.
+  """
+  @spec apply_changes(Canvas.t(), Changes.t()) :: {:ok, Canvas.t()} | {:error, :out_of_bounds}
+  def apply_changes(%Canvas{} = canvas, %Changes{} = changes) do
+    Enum.reduce_while(changes.fields, {:ok, canvas}, fn {point, character}, {:ok, canvas} ->
+      case put(canvas, point, <<character>>) do
+        {:ok, canvas} -> {:cont, {:ok, canvas}}
+        {:error, error} -> {:halt, {:error, error}}
+      end
+    end)
   end
 end

--- a/apps/draw/lib/draw/engine/canvas/changes.ex
+++ b/apps/draw/lib/draw/engine/canvas/changes.ex
@@ -1,0 +1,10 @@
+defmodule Draw.Engine.Canvas.Changes do
+  @moduledoc """
+  Structure which stores changes applied to the canvas fields.
+  """
+  alias Draw.Engine.Canvas.Changes
+
+  @type t :: %Changes{}
+
+  defstruct fields: %{}
+end

--- a/apps/draw/lib/draw/engine/canvas/operation.ex
+++ b/apps/draw/lib/draw/engine/canvas/operation.ex
@@ -1,14 +1,16 @@
 defprotocol Draw.Engine.Canvas.Operation do
   @moduledoc """
   Drawing operation protocol. Different operations have to implement this protocol to be
-  handled by the Engine.
+  handled by the Engine. The `process/2` function will return `Changes` struct.
   """
   alias Draw.Engine.Canvas
+  alias Draw.Engine.Canvas.Changes
   alias Draw.Engine.Canvas.Operation
 
   @doc """
-  Proceed with canvas operation
+  Proceed with canvas operation. Will return `%Changes{}` struct that can be later applied to
+  the canvas.
   """
-  @spec process(Operation.t(), Canvas.t()) :: {:ok, Canvas.t()} | {:error, atom()}
+  @spec process(Operation.t(), Canvas.t()) :: {:ok, Changes.t()} | {:error, atom()}
   def process(operation, canvas)
 end

--- a/apps/draw/lib/draw/engine/canvas/operation/point.ex
+++ b/apps/draw/lib/draw/engine/canvas/operation/point.ex
@@ -6,13 +6,14 @@ defmodule Draw.Engine.Canvas.Operation.Point do
   defstruct [:point, :character]
 
   alias Draw.Engine.Canvas
+  alias Draw.Engine.Canvas.Changes
   alias Draw.Engine.Canvas.Operation
   alias Draw.Engine.Canvas.Operation.Point
 
   defimpl Operation do
-    def process(%Point{point: point, character: <<character>>}, %Canvas{fields: fields} = canvas) do
+    def process(%Point{point: point, character: <<character>>}, %Canvas{} = canvas) do
       if Canvas.at(canvas, point) != nil do
-        {:ok, %{canvas | fields: %{fields | point => character}}}
+        {:ok, %Changes{fields: %{point => character}}}
       else
         {:error, :out_of_bounds}
       end

--- a/apps/draw/test/draw/engine/canvas/operation/point_test.exs
+++ b/apps/draw/test/draw/engine/canvas/operation/point_test.exs
@@ -3,6 +3,7 @@ defmodule Draw.Engine.Canvas.Operation.PointTest do
   use ExUnitProperties
 
   alias Draw.Engine.Canvas
+  alias Draw.Engine.Canvas.Changes
   alias Draw.Engine.Canvas.Operation
   alias Draw.Engine.Canvas.Operation.Point
 
@@ -11,8 +12,8 @@ defmodule Draw.Engine.Canvas.Operation.PointTest do
       canvas = Canvas.new()
       point = %Point{point: {1, 2}, character: "A"}
 
-      assert {:ok, canvas} = Operation.process(point, canvas)
-      assert Canvas.at(canvas, {1, 2}) == "A"
+      assert {:ok, %Changes{fields: fields}} = Operation.process(point, canvas)
+      assert %{{1, 2} => 65} == fields
     end
 
     test "doesn't add point if out of bounds" do
@@ -28,14 +29,10 @@ defmodule Draw.Engine.Canvas.Operation.PointTest do
                 x <- integer(0..(width - 1)),
                 y <- integer(0..(height - 1)),
                 canvas = Canvas.new(width, height, " "),
-                point = %Point{point: {x, y}, character: character} do
-        assert {:ok, canvas} = Operation.process(point, canvas)
-
-        for i <- 0..(width - 1), j <- 0..(height - 1), i != x && j != y do
-          assert Canvas.at(canvas, {i, j}) == " "
-        end
-
-        assert Canvas.at(canvas, {x, y}) == character
+                point = %Point{point: {x, y}, character: character},
+                <<char_code>> = character do
+        assert {:ok, %Changes{fields: fields}} = Operation.process(point, canvas)
+        assert %{{x, y} => char_code} == fields
       end
     end
   end

--- a/apps/draw/test/draw/engine/canvas/operation_test.exs
+++ b/apps/draw/test/draw/engine/canvas/operation_test.exs
@@ -1,13 +1,14 @@
 defmodule Draw.Engine.Canvas.OperationTest do
   use ExUnit.Case
   alias Draw.Engine.Canvas
+  alias Draw.Engine.Canvas.Changes
   alias Draw.Engine.Canvas.Operation
   alias Draw.Engine.Canvas.Operation.Noop
 
   describe "process/2" do
     test "Proceed with noop (no changes)" do
       canvas = Canvas.new()
-      assert Operation.process(%Noop{}, canvas) == {:ok, canvas}
+      assert {:ok, %Changes{}} == Operation.process(%Noop{}, canvas)
     end
   end
 end

--- a/apps/draw/test/draw/engine/canvas_test.exs
+++ b/apps/draw/test/draw/engine/canvas_test.exs
@@ -3,6 +3,7 @@ defmodule Draw.Engine.CanvasTest do
   use ExUnitProperties
 
   alias Draw.Engine.Canvas
+  alias Draw.Engine.Canvas.Changes
 
   doctest Draw.Engine.Canvas
 
@@ -43,7 +44,7 @@ defmodule Draw.Engine.CanvasTest do
     end
   end
 
-  describe "put/2" do
+  describe "put/3" do
     test "puts a value on position" do
       canvas = Canvas.new()
       assert {:ok, canvas} = Canvas.put(canvas, {0, 0}, "d")
@@ -53,6 +54,51 @@ defmodule Draw.Engine.CanvasTest do
     test "returns error if the point is out of bounds" do
       canvas = Canvas.new()
       assert {:error, :out_of_bounds} = Canvas.put(canvas, {100, 100}, "d")
+    end
+  end
+
+  describe "apply_changes/2" do
+    setup do
+      %{canvas: Canvas.new(5, 5, ".")}
+    end
+
+    test "applies no changes", %{canvas: canvas} do
+      assert {:ok, canvas} == Canvas.apply_changes(canvas, %Changes{})
+    end
+
+    test "applies one change", %{canvas: canvas} do
+      changes = %Changes{fields: %{{1, 1} => 65}}
+      assert {:ok, canvas} = Canvas.apply_changes(canvas, changes)
+
+      expected_canvas = """
+      .....
+      .A...
+      .....
+      .....
+      .....
+      """
+
+      assert expected_canvas == to_string(canvas)
+    end
+
+    test "applies multiple changes", %{canvas: canvas} do
+      changes = %Changes{fields: %{{1, 1} => 65, {2, 2} => 66, {3, 4} => 67}}
+      assert {:ok, canvas} = Canvas.apply_changes(canvas, changes)
+
+      expected_canvas = """
+      .....
+      .A...
+      ..B..
+      .....
+      ...C.
+      """
+
+      assert expected_canvas == to_string(canvas)
+    end
+
+    test "returns error if changes out of bounds", %{canvas: canvas} do
+      changes = %Changes{fields: %{{5, 5} => 65}}
+      assert {:error, :out_of_bounds} == Canvas.apply_changes(canvas, changes)
     end
   end
 end

--- a/apps/draw/test/support/draw/engine/canvas/operation/noop.ex
+++ b/apps/draw/test/support/draw/engine/canvas/operation/noop.ex
@@ -1,8 +1,9 @@
 defmodule Draw.Engine.Canvas.Operation.Noop do
+  alias Draw.Engine.Canvas.Changes
   alias Draw.Engine.Canvas.Operation
   defstruct []
 
   defimpl Operation do
-    def process(_noop, canvas), do: {:ok, canvas}
+    def process(_noop, _canvas), do: {:ok, %Changes{}}
   end
 end


### PR DESCRIPTION
Use `apply_changes/2` in Engine - `Operation` protocol will now return `Changes` struct which won't be modifying canvas yet. `Engine` has to explicitly call `apply_changes/2` to add the change to the `Canvas` now.